### PR TITLE
Ensure the loading spinner appears over the placeholder image

### DIFF
--- a/Kingfisher/UIImageView+Kingfisher.swift
+++ b/Kingfisher/UIImageView+Kingfisher.swift
@@ -182,6 +182,10 @@ public extension UIImageView {
             indicator = kf_indicator
             indicator?.hidden = false
             indicator?.startAnimating()
+
+            if let spinner = indicator {
+              self.bringSubviewToFront(spinner)
+            }
         }
         
         image = placeholderImage


### PR DESCRIPTION
@BCOVJRad when using kingfisher's placeholder option and a spinner, the spinner appears underneath the placeholder, so this moves it to the front.
